### PR TITLE
Make external post inbox updates async and fix a bug

### DIFF
--- a/backend/webserver/api_client.py
+++ b/backend/webserver/api_client.py
@@ -1,5 +1,7 @@
 import requests
 import logging
+import aiohttp
+import asyncio
 
 logger = logging.getLogger(__name__)
 
@@ -21,3 +23,16 @@ def http_request(method, url, node, expected_status=requests.codes.ok, timeout=5
     except requests.exceptions.RequestException as e:
         logger.error(e)
     return None, 500
+
+async def async_http_request(method, url, node, expected_status=200, **kwargs):
+    async with aiohttp.ClientSession() as session:
+        async with session.request(method, url, auth=aiohttp.BasicAuth(node.auth_username, node.auth_password), 
+                                   **kwargs) as response:
+            if response.status != expected_status:
+                logger.error(f"{method} request to {url} failed due to unexpected status code {response.status}")
+                return None, response.status
+            try:
+                return await response.json(), response.status
+            except aiohttp.ContentTypeError as e:
+                logger.warning(f'{method} request to {url} returned non-json response.')
+                return None, response.status

--- a/backend/webserver/models.py
+++ b/backend/webserver/models.py
@@ -6,7 +6,7 @@ import uuid
 from .utils import join_urls
 from .converters import Converter, Team10Converter, Team11Converter
 from urllib.parse import urlparse
-from .api_client import http_request
+from .api_client import http_request, async_http_request
 
 class AuthorUserManager(BaseUserManager):
     def create_user(self, username, password=None):
@@ -187,49 +187,45 @@ class Post(models.Model):
     ]
     content_type = models.CharField(max_length=200,choices=CONTENT_TYPE_CHOICES,default="text/plain")
     content = models.TextField(blank=True)
-    
-    # TODO: how much work will it take to make all of the following POST requests async?
+
     # TODO: might need to add some retry logic for inbox updates over http
     
     def update_author_inbox_over_http(self, url, node, author):
         node_converter = node.get_converter()
-        return http_request("POST", url=url, node=node, 
-                            expected_status=node_converter.expected_status_code("send_post_inbox"),
-                            json=node_converter.send_post_inbox(author, self.id), timeout=3)
+        return async_http_request("POST", url=url, node=node,
+                                  expected_status=node_converter.expected_status_code("send_post_inbox"),
+                                  json=node_converter.send_post_inbox(author, self.id))
 
-    # returns True only if all requests were successful
     def send_to_followers(self):
-        success = True
+        update_reqs = []
         for follow in self.author.followed_by_authors.iterator():
             if follow.remote_follower:
                 node = follow.remote_follower.node
-                res, _ = self.update_author_inbox_over_http(url=follow.remote_follower.get_inbox_url(),
-                                                            node=node, author=follow.remote_follower)
-                if res is None:
-                    success = False
+                update_reqs.append(
+                    self.update_author_inbox_over_http(url=follow.remote_follower.get_inbox_url(),
+                                                       node=node, author=follow.remote_follower)
+                )
             else:
                 Inbox.objects.create(target_author=follow.follower, post=self)
-        return success
+        return update_reqs
     
-    # returns True only if all requests were successful
     def send_to_all_authors(self):
-        success = True
         for author in Author.objects.exclude(id=self.author.id).iterator():
             Inbox.objects.create(target_author=author, post=self)
         # fetch all authors on all nodes and update their inboxes
+        update_reqs = []
         for node in Node.objects.all():
             node_converter = node.get_converter()
             res, _ = http_request("GET", node.get_authors_url(), node=node)
             if res is None:
-                success = False
                 continue
             authors = node_converter.convert_authors(res)
             for author in authors:
                 url = join_urls(author["url"], "inbox", ends_with_slash=True)
-                res, _ = self.update_author_inbox_over_http(url=url, node=node, author=author)
-                if res is None:
-                    success = False
-        return success
+                update_reqs.append(
+                    self.update_author_inbox_over_http(url=url, node=node, author=author)
+                )
+        return update_reqs
 
 
 class Comment(models.Model):

--- a/backend/webserver/serializers.py
+++ b/backend/webserver/serializers.py
@@ -130,6 +130,13 @@ class PostLikeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Like
         fields = ['author','post']
+    
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        # Mark: I am doing this so that I can display the post like this 
+        # "object":"http://127.0.0.1:5454/authors/9de17f29c12e8f97bcbbd34cc908f1baba40658e/posts/764efa883dda1e11db47671c4a3bbd9e"
+        data['post'] = join_urls(data['author']['url'], "posts", str(data['post']), ends_with_slash=True)
+        return data
 
 class AcceptOrDeclineFollowRequestSerializer(serializers.Serializer):
     follow_request_sender = ActorSerializer()

--- a/backend/webserver/views.py
+++ b/backend/webserver/views.py
@@ -315,11 +315,7 @@ class AuthorLikedView(APIView):
     def get(self,requst,pk):
         author = get_object_or_404(Author,pk=pk)
         likes = Like.objects.filter(post__visibility="PUBLIC").filter(author=author)
-        serializer = PostLikeSerializer(likes, many=True, context={'request': requst})
-        # I am doing this so that I can display the post like this "object":"http://127.0.0.1:5454/authors/9de17f29c12e8f97bcbbd34cc908f1baba40658e/posts/764efa883dda1e11db47671c4a3bbd9e"
-        for data in serializer.data: 
-            data['post'] = urljoin(data['author']['url'],  f"posts/{data['post']}/")
-            
+        serializer = PostLikeSerializer(likes, many=True, context={'request': requst}) 
         return Response(serializer.data, status=status.HTTP_200_OK)
         
 
@@ -331,10 +327,6 @@ class PostLikesView(APIView):
         post = get_object_or_404(Post,id=post_id,author=author.id)
         likes = Like.objects.filter(post=post.id)
         serializer = PostLikeSerializer(likes, many=True, context={'request': requst})
-        # I am doing this so that I can display the post like this "object":"http://127.0.0.1:5454/authors/9de17f29c12e8f97bcbbd34cc908f1baba40658e/posts/764efa883dda1e11db47671c4a3bbd9e"
-        for data in serializer.data: 
-            data['post'] = urljoin(data['author']['url'],  f"posts/{data['post']}/")
-            
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 class FollowRequestsView(APIView):
@@ -625,9 +617,6 @@ class InboxView(APIView, PaginationHandlerMixin):
             )
         else:
             serializer = self.get_serializer(request, queryset)
-        for data in serializer.data:
-            if data['type'] == "like":
-                data['post'] = urljoin(data['author']['url'],  f"posts/{data['post']}/")
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def post(self, request, author_id):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,19 @@
+aiohttp==3.8.3
+aioresponses==0.7.3
+aiosignal==1.3.1
 asgiref==3.5.2
+async-timeout==4.0.2
+attrs==22.1.0
 certifi==2022.9.24
 charset-normalizer==2.1.1
 dj-database-url==1.0.0
 Django==4.1.2
 django-on-heroku==1.1.2
 djangorestframework==3.14.0
+frozenlist==1.3.3
 gunicorn==20.1.0
 idna==3.4
+multidict==6.0.2
 psycopg2-binary==2.9.5
 pytz==2022.4
 requests==2.28.1
@@ -16,3 +23,4 @@ toml==0.10.2
 types-toml==0.10.8
 urllib3==1.26.12
 whitenoise==6.2.0
+yarl==1.8.1


### PR DESCRIPTION
## Changes
* Implements a new `async_http_request` method in `api_client` that allows us to send async http requests in Python using the [`aiohttp` library](https://docs.aiohttp.org/en/stable/client_quickstart.html)
* `update_author_inbox_over_http` now sends asyc requests
  * Why is this introduced? Imagine a scenario where a local author has 10 remote followers. When the author creates a new post, we need to update the inbox of all of their remote followers. Doing that synchronously would cost us 10 additional http requests. This could take several seconds and our frontend would be left hanging.
  * With async, we are going to return a response to our frontend immediately and the inbox updates would still be sent asynchronously
* The new [`aioresponses` library](https://pypi.org/project/aioresponses/) allows us to mock responses to async http requests. This works very similarly to the `responses` library that we are already using.
  * We cannot test async code and use Django database queries such as `Post.objects.create` at the same time because Django ORM is synchronous. Fortunately, Django provides the function [`sync_to_async`](https://docs.djangoproject.com/en/4.1/topics/async/) that allows us to convert any sync function into async.
* Fixes the following bug related to the likes implementation - 
![image](https://user-images.githubusercontent.com/43586048/202834556-ce001a73-3074-4eb0-8877-d452efa77f63.png)
