### PR TITLE
Add team 11's converter

### DIFF
--- a/backend/webserver/fixtures/prod_1_seed.json
+++ b/backend/webserver/fixtures/prod_1_seed.json
@@ -17,6 +17,22 @@
 },
 {
     "model": "webserver.author",
+    "pk": "58edac43-30c2-411e-87d5-ecf3f27a2a12",
+    "fields": {
+        "password": "pbkdf2_sha256$390000$5g2rDaHQQ35laqHmWH45Lg$zkLTvbJSeDOZzxAFarbpU0UN+v55aQ/3UlnAtmlawUU=",
+        "last_login": null,
+        "username": "team11",
+        "display_name": "team11",
+        "profile_image": "",
+        "github_handle": "",
+        "created_at": "2022-11-27T22:48:12.125Z",
+        "is_active": true,
+        "is_admin": false,
+        "is_remote_user": true
+    }
+},
+{
+    "model": "webserver.author",
     "pk": "6667e232-2b87-4793-9dba-62c77f68b016",
     "fields": {
         "password": "pbkdf2_sha256$390000$VFhNfdhjSXGhf63cQcH4UB$91HvPr1uSdmew/QUvKS7jtJXHmPyCE8KM1Q5KLUg7lM=",
@@ -94,6 +110,17 @@
         "auth_username": "one4one6",
         "auth_password": "one4one6",
         "team": 16
+    }
+},
+{
+    "model": "webserver.node",
+    "pk": 4,
+    "fields": {
+        "user": "58edac43-30c2-411e-87d5-ecf3f27a2a12",
+        "api_url": "https://cmsjmnet.herokuapp.com/",
+        "auth_username": "team14",
+        "auth_password": "team14",
+        "team": 11
     }
 }
 ]

--- a/backend/webserver/tests/test_views.py
+++ b/backend/webserver/tests/test_views.py
@@ -769,6 +769,81 @@ class FollowRequestProcessorTestCase(APITestCase):
         self.assertEqual(0, FollowRequest.objects.count())
     
     @responses.activate
+    def test_receiver_is_remote_author_for_team11(self):
+        local_author = Author.objects.create(username="local_author", display_name="local_author")
+        node_user_1 = Author.objects.create(username="node_user_1", display_name="node_user_1", 
+                                            password="password1", is_remote_user=True)
+        Node.objects.create(api_url="https://social-distribution-1.herokuapp.com/api", user=node_user_1,
+                            auth_username="team11", auth_password="password-team11", team=11)
+        remote_author_id = uuid.uuid4()
+        payload = {
+            "type": "follow",
+            "sender": {
+                "url": f'http://testserver.com/api/authors/{local_author.id}/',
+                "id": str(local_author.id),
+            },
+            "receiver": {
+                "url": f'https://social-distribution-1.herokuapp.com/api/authors/{remote_author_id}/',
+                "id": str(remote_author_id),
+            }
+        }
+        
+        responses.add(
+            responses.GET,
+            f"https://social-distribution-1.herokuapp.com/api/authors/{remote_author_id}/followers/{local_author.id}",
+            status=404, # local author does not follow remote author yet
+        )
+        remote_author_json = {
+            "type": "author",
+            "id": f"https://social-distribution-1.herokuapp.com/api/authors/{remote_author_id}",
+            "host": "https://social-distribution-1.herokuapp.com/api",
+            "displayName": "test_user",
+            "url": f"https://social-distribution-1.herokuapp.com/api/authors/{remote_author_id}",
+            "github": "",
+            "profileImage": "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png"
+        }
+        responses.add(
+            responses.GET,
+            f"https://social-distribution-1.herokuapp.com/api/authors/{remote_author_id}/",
+            json=remote_author_json,
+            status=200,
+        )
+        
+        expected_payload = {
+            "type": "inbox",
+            "author": f'https://social-distribution-1.herokuapp.com/api/authors/{remote_author_id}/',
+            "items": [{
+                "type": "follow",
+                "actor": {
+                    "type": "author",
+                    "id": f"http://testserver.com/api/authors/{local_author.id}/",
+                    "host": "http://testserver/",
+                    "displayName": local_author.display_name,
+                    "github": local_author.github_handle,
+                    "url": f"http://testserver.com/api/authors/{local_author.id}/",
+                    "profileImage": local_author.profile_image,
+                },
+                "object": remote_author_json,
+            }]
+        }
+
+        responses.add(
+            responses.POST,
+            f"https://social-distribution-1.herokuapp.com/api/authors/{remote_author_id}/inbox/",
+            match=[
+                matchers.json_params_matcher(expected_payload),  # team 11's follow request payload
+            ],
+            status=201,
+        )
+        
+        url = f'/api/authors/{remote_author_id}/inbox/'
+        self.client.force_authenticate(user=local_author)
+        response = self.client.post(url, data=payload, format="json")
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
+        # shouldn't create a local FR object for a remote receiver
+        self.assertEqual(0, FollowRequest.objects.count())
+    
+    @responses.activate
     def test_receiver_is_remote_author_for_team10(self):
         local_author = Author.objects.create(username="local_author", display_name="local_author")
         node_user_1 = Author.objects.create(username="node_user_1", display_name="node_user_1", 

--- a/backend/webserver/views.py
+++ b/backend/webserver/views.py
@@ -431,7 +431,7 @@ class FollowRequestProcessor(object):
                     url = node_converter.url_to_send_follow_request_at(serializer.data["receiver"]["url"])
                     res, res_status = http_request("POST", url, node=node,
                                                    expected_status=node_converter.expected_status_code("send_follow_request"), 
-                                                   json=node_converter.send_follow_request(request.data))
+                                                   json=node_converter.send_follow_request(request.data, request))
                     if res is None:
                         return Response("Failed to send remote follow request due to remote node failure", status=res_status)
                     return Response({'message': 'OK'}, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
## Changes
* Added all the basic converter methods for team 11. I did not add all the tests because of the time crunch.
  * After merging and deploying this PR, we will need to see if we can see team 11's posts in our frontend, as well as test other interactions with team 11 from the frontend.
* Added team 11's credentials
  * For us to connect to them: `username: team14` `password: team14`
  * For them to connect to us: `username: team11` `password: team11`